### PR TITLE
Redirect owners to dashboard after auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -4,10 +4,10 @@ exports.postLogin=async (req,res)=>{ const { email,password }=req.body; const us
  if(!user){ req.flash('message','Usuario no encontrado'); return res.redirect('/login'); }
  const ok=await bcrypt.compare(password,user.passwordHash);
  if(!ok){ req.flash('message','Credenciales inválidas'); return res.redirect('/login'); }
- req.session.userId=user.id; req.session.role=user.role; res.redirect('/dashboard'); };
+ req.session.userId=user.id; req.session.role=user.role; if(user.role==='owner'){ res.redirect('/owner/dashboard'); } else { res.redirect('/dashboard'); } };
 exports.getRegister=(req,res)=> res.render('register',{ message:req.flash('message') });
 exports.postRegister=async (req,res)=>{ const {name,email,password,role}=req.body;
  const exists=await User.findOne({ where:{ email } }); if(exists){ req.flash('message','El email ya está registrado'); return res.redirect('/register'); }
  const passwordHash=await bcrypt.hash(password,10); const user=await User.create({ name,email,passwordHash,role });
- req.session.userId=user.id; req.session.role=user.role; res.redirect('/onboarding/step1'); };
+ req.session.userId=user.id; req.session.role=user.role; if(user.role==='owner'){ res.redirect('/owner/dashboard'); } else { res.redirect('/onboarding/step1'); } };
 exports.logout=(req,res)=>{ req.session.destroy(()=>res.redirect('/')); };


### PR DESCRIPTION
## Summary
- Route owners to `/owner/dashboard` when logging in or registering
- Ignore `node_modules` via `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68974c611a948328b6adf8ad56612870