### PR TITLE
Restrict tenant routes to tenant role

### DIFF
--- a/src/controllers/tenantController.js
+++ b/src/controllers/tenantController.js
@@ -1,5 +1,5 @@
 const TenantProfile = require('../models/TenantProfile');
-exports.ensureAuth=(req,res,next)=>{ if(!req.session.userId) return res.redirect('/login'); next(); };
+exports.ensureAuth=(req,res,next)=>{ if(!req.session.userId||req.session.role!=='tenant') return res.redirect('/login'); next(); };
 exports.dashboard=async (req,res)=>{ res.render('dashboard'); };
 exports.getStep1=async (req,res)=>{ const profile=await TenantProfile.findOne({ where:{ userId:req.session.userId } }); res.render('tenant/step1',{ profile }); };
 exports.postStep1=async (req,res)=>{ const d=(({profession,seniority,salary,legalStatus,nationality,pets,roommates})=>({profession,seniority,salary,legalStatus,nationality,pets,roommates}))(req.body);

--- a/src/routes/tenant.js
+++ b/src/routes/tenant.js
@@ -1,7 +1,8 @@
 const express=require('express'); const router=express.Router(); const t=require('../controllers/tenantController');
 const multer=require('multer'); const path=require('path'); const upload=multer({ dest:path.join(__dirname,'../../uploads') });
-router.get('/dashboard', t.ensureAuth, t.dashboard);
-router.get('/onboarding/step1', t.ensureAuth, t.getStep1); router.post('/onboarding/step1', t.ensureAuth, t.postStep1);
-router.get('/onboarding/step2', t.ensureAuth, t.getStep2); router.post('/onboarding/step2', t.ensureAuth, t.postStep2);
-router.get('/onboarding/step3', t.ensureAuth, t.getStep3); router.post('/onboarding/step3', t.ensureAuth, upload.fields([{name:'idDoc',maxCount:1},{name:'lastPayslip',maxCount:1},{name:'workContract',maxCount:1},{name:'cv',maxCount:1},{name:'selfie',maxCount:1}]), t.postStep3);
-router.get('/onboarding/done', t.ensureAuth, t.done); module.exports=router;
+router.use(t.ensureAuth);
+router.get('/dashboard', t.dashboard);
+router.get('/onboarding/step1', t.getStep1); router.post('/onboarding/step1', t.postStep1);
+router.get('/onboarding/step2', t.getStep2); router.post('/onboarding/step2', t.postStep2);
+router.get('/onboarding/step3', t.getStep3); router.post('/onboarding/step3', upload.fields([{name:'idDoc',maxCount:1},{name:'lastPayslip',maxCount:1},{name:'workContract',maxCount:1},{name:'cv',maxCount:1},{name:'selfie',maxCount:1}]), t.postStep3);
+router.get('/onboarding/done', t.done); module.exports=router;


### PR DESCRIPTION
## Summary
- Enforce that `ensureAuth` validates session role is `tenant`
- Apply tenant auth middleware to all tenant routes using `router.use`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897504ae0448328aaeffd5dbe18732e