### PR TITLE
Handle owner-initiated likes

### DIFF
--- a/src/controllers/propertyController.js
+++ b/src/controllers/propertyController.js
@@ -4,7 +4,11 @@ exports.detail=async (req,res)=>{ const p=await Property.findByPk(req.params.id)
 exports.like=async (req,res)=>{ if(!req.session.userId||req.session.role!=='tenant'){ req.flash('message','Debes ingresar como inquilino'); return res.redirect('/login'); }
  const propertyId=req.params.id; let m=await Match.findOne({ where:{ userId:req.session.userId, propertyId } });
  if(!m){ m=await Match.create({ userId:req.session.userId, propertyId, status:'liked' }); req.flash('message','¡Enviado! Si el propietario también te elige, habrá Match.'); }
- else if(m.status==='liked'){ req.flash('message','Ya habías indicado interés por esta propiedad.'); }
+ else if(m.status==='liked'){
+     m.status='matched';
+     await m.save();
+     req.flash('message','¡Se produjo un Match con el propietario!');
+ }
  else if(m.status==='rejected'){ m.status='liked'; await m.save(); req.flash('message','Se actualizó tu interés.'); }
  else { req.flash('message','¡Ya hay Match en esta propiedad!'); } return res.redirect('/properties/'+propertyId); };
 exports.ownerList=async (req,res)=>{ if(!req.session.userId||req.session.role!=='owner') return res.redirect('/login');


### PR DESCRIPTION
## Summary
- Mark matches as complete when tenants like properties already liked by owners
- Inform tenants when a property like becomes a mutual match

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6897505370c88328bc7e3db2c496c0e2