### PR TITLE
Implement property controller listing and match endpoints

### DIFF
--- a/src/controllers/propertyController.js
+++ b/src/controllers/propertyController.js
@@ -1,3 +1,28 @@
+const Property = require('../models/Property');
+const Match = require('../models/Match');
+
+exports.list = async (req, res) => {
+  const props = await Property.findAll();
+  res.render('properties/list', { props });
+};
+
+exports.detail = async (req, res) => {
+  const p = await Property.findByPk(req.params.id);
+  if (!p) {
+    req.flash('message', 'Propiedad no encontrada');
+    return res.redirect('/properties');
+  }
+  res.render('properties/detail', { p, message: req.flash('message') });
+};
+
+exports.matchesForTenant = async (req, res) => {
+  if (!req.session.userId || req.session.role !== 'tenant') {
+    return res.redirect('/login');
+  }
+  const matches = await Match.findAll({ where: { userId: req.session.userId, status: 'matched' } });
+  res.render('tenant/matches', { matches });
+};
+
 exports.like = async (req, res) => {
   if (!req.session.userId || req.session.role !== 'tenant') {
     req.flash('message', 'Debes ingresar como inquilino');


### PR DESCRIPTION
## Summary
- import Property and Match models
- implement list, detail, and matchesForTenant handlers
- retain existing like handler

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68975605da48832882b148a8accf0e06