### PR TITLE
Add auth role selection view and role-aware login

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,5 +1,5 @@
 const bcrypt = require('bcrypt'); const User = require('../models/User');
-exports.getLogin=(req,res)=> res.render('login',{ message:req.flash('message') });
+exports.getLogin=(req,res)=> res.render('login',{ message:req.flash('message'), role:req.query.role });
 exports.postLogin=async (req,res)=>{ const { email,password }=req.body; const user=await User.findOne({ where:{ email } });
  if(!user){ req.flash('message','Usuario no encontrado'); return res.redirect('/login'); }
  const ok=await bcrypt.compare(password,user.passwordHash);
@@ -11,3 +11,4 @@ exports.postRegister=async (req,res)=>{ const {name,email,password,role}=req.bod
  const passwordHash=await bcrypt.hash(password,10); const user=await User.create({ name,email,passwordHash,role });
  req.session.userId=user.id; req.session.role=user.role; if(user.role==='owner'){ res.redirect('/owner/dashboard'); } else { res.redirect('/onboarding/step1'); } };
 exports.logout=(req,res)=>{ req.session.destroy(()=>res.redirect('/')); };
+exports.getAuthChoice=(req,res)=> res.render('auth-choice',{ role:req.query.role });

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,4 +1,4 @@
 const express=require('express'); const router=express.Router(); const auth=require('../controllers/authController');
-router.get('/login',auth.getLogin); router.post('/login',auth.postLogin);
+router.get('/auth-choice',auth.getAuthChoice); router.get('/login',auth.getLogin); router.post('/login',auth.postLogin);
 router.get('/register',auth.getRegister); router.post('/register',auth.postRegister);
 router.post('/logout',auth.logout); module.exports=router;

--- a/src/views/auth-choice.ejs
+++ b/src/views/auth-choice.ejs
@@ -1,0 +1,7 @@
+<%- include('partials/header') %>
+<h2><%= role === 'owner' ? 'Propietario' : 'Inquilino' %></h2>
+<div class="cta-row">
+  <a class="btn" href="/login?role=<%= role %>">Iniciar sesión</a>
+  <a class="btn-outline" href="/register?role=<%= role %>">Registrarse</a>
+</div>
+<%- include('partials/footer') %>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -1,5 +1,5 @@
 <%- include('partials/header') %>
 <section class="hero"><h1>Conectamos propietarios con inquilinos ideales</h1>
 <p>Accedé a alquileres donde tu perfil vale más que tu rapidez.</p>
-<div class="cta-row"><a class="btn" href="/register">Soy Inquilino</a><a class="btn-outline" href="/register?role=owner">Soy Propietario</a></div>
+<div class="cta-row"><a class="btn" href="/auth-choice?role=tenant">Soy Inquilino</a><a class="btn-outline" href="/auth-choice?role=owner">Soy Propietario</a></div>
 </section><%- include('partials/footer') %>

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -1,7 +1,9 @@
-<%- include('partials/header') %><h2>Login or join</h2>
+<%- include('partials/header') %>
+<% const label = role === 'owner' ? 'Propietario' : 'Inquilino'; %>
+<h2>Iniciar sesión<% if (role) { %> como <%= label %><% } %></h2>
 <% if (message && message.length) { %><div class="flash"><%= message %></div><% } %>
 <form method="post" action="/login" class="form">
 <label>Email <input type="email" name="email" required/></label>
 <label>Contraseña <input type="password" name="password" required/></label>
 <button class="btn" type="submit">Ingresar</button></form>
-<p>¿No tienes cuenta? <a href="/register">Regístrate</a></p><%- include('partials/footer') %>
+<p>¿No tienes cuenta? <a href="/register?role=<%= role %>">Regístrate</a></p><%- include('partials/footer') %>


### PR DESCRIPTION
## Summary
- Introduce auth-choice view with role-specific options to log in or register.
- Add route and controller for auth-choice and pass role through login.
- Update home and login views to use role-aware links and messages.

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_6897622fadf483289779826630506d70