### PR TITLE
Ensure session save before auth redirects

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -4,7 +4,7 @@ exports.postLogin=async (req,res)=>{ const { email,password }=req.body; const us
  if(!user){ req.flash('message','Usuario no encontrado'); return res.redirect('/login'); }
  const ok=await bcrypt.compare(password,user.passwordHash);
  if(!ok){ req.flash('message','Credenciales inválidas'); return res.redirect('/login'); }
- req.session.userId=user.id; req.session.role=user.role; if(user.role==='owner'){ res.redirect('/owner/dashboard'); } else { res.redirect('/dashboard'); } };
+ req.session.userId=user.id; req.session.role=user.role; req.session.save(()=>{ if(user.role==='owner') return res.redirect('/owner/dashboard'); res.redirect('/dashboard'); }); };
 
 exports.getRegister=(req,res)=>
   res.render('register', {
@@ -14,6 +14,6 @@ exports.getRegister=(req,res)=>
 exports.postRegister=async (req,res)=>{ const {name,email,password,role}=req.body;
  const exists=await User.findOne({ where:{ email } }); if(exists){ req.flash('message','El email ya está registrado'); return res.redirect('/register'); }
  const passwordHash=await bcrypt.hash(password,10); const user=await User.create({ name,email,passwordHash,role });
- req.session.userId=user.id; req.session.role=user.role; if(user.role==='owner'){ res.redirect('/owner/dashboard'); } else { res.redirect('/onboarding/step1'); } };
+ req.session.userId=user.id; req.session.role=user.role; req.session.save(()=>{ if(user.role==='owner') return res.redirect('/owner/dashboard'); res.redirect('/onboarding/step1'); }); };
 exports.logout=(req,res)=>{ req.session.destroy(()=>res.redirect('/')); };
 exports.getAuthChoice=(req,res)=> res.render('auth-choice',{ role:req.query.role });


### PR DESCRIPTION
## Summary
- Save session before redirecting after login and registration

## Testing
- `npm test` *(fails: Missing script "test")*
- Manual registration & login with tenant: `/dashboard` returns 200
- Manual registration & login with owner: `/owner/dashboard` redirected to /login


------
https://chatgpt.com/codex/tasks/task_e_6898ea6f34508328951eec216d00c2a1