### PR TITLE
chore: clean up login view instructions

### DIFF
--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -20,13 +20,3 @@
 </p>
 
 <%- include('partials/footer') %>
-Y asegúrate de que en el controlador pases el rol (con valor por defecto):
-
-js
-Copiar
-Editar
-// authController.js
-exports.getLogin = (req, res) => {
-  const role = req.query.role || 'tenant';
-  res.render('login', { message: req.flash('message'), role });
-};


### PR DESCRIPTION
## Summary
- remove leftover instructional lines in login view so only the login form and links display

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898ff099fe48328af54a6005108264e