### PR TITLE
Redirect owner onboarding flow

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -14,6 +14,6 @@ exports.getRegister=(req,res)=>
 exports.postRegister=async (req,res)=>{ const {name,email,password,role}=req.body;
  const exists=await User.findOne({ where:{ email } }); if(exists){ req.flash('message','El email ya está registrado'); return res.redirect('/register'); }
  const passwordHash=await bcrypt.hash(password,10); const user=await User.create({ name,email,passwordHash,role });
- req.session.userId=user.id; req.session.role=user.role; req.session.save(()=>{ if(user.role==='owner') return res.redirect('/owner/dashboard'); res.redirect('/onboarding/step1'); }); };
+ req.session.userId=user.id; req.session.role=user.role; req.session.save(()=>{ if(user.role==='owner') return res.redirect('/owner/profile'); res.redirect('/onboarding/step1'); }); };
 exports.logout=(req,res)=>{ req.session.destroy(()=>res.redirect('/')); };
 exports.getAuthChoice=(req,res)=> res.render('auth-choice',{ role:req.query.role });

--- a/src/controllers/ownerController.js
+++ b/src/controllers/ownerController.js
@@ -35,7 +35,7 @@ exports.postProfile = async (req, res) => {
   } else {
     await OwnerProfile.create(data);
   }
-  res.redirect('/owner/profile');
+  res.redirect('/owner/preferences');
 };
 
 exports.getPreferences = async (req, res) => {
@@ -62,5 +62,5 @@ exports.postPreferences = async (req, res) => {
   } else {
     await OwnerPreference.create(data);
   }
-  res.redirect('/owner/preferences');
+  res.redirect('/owner/dashboard');
 };


### PR DESCRIPTION
## Summary
- Redirect owners to profile after registration
- Send owners to preferences page after saving profile
- After saving preferences, redirect to owner dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run db:reset` *(fails: sqlite3 invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_68a064cbefc08328aad2d372dda12950