### PR TITLE
Fix SQLite path and align Property model

### DIFF
--- a/src/models/Property.js
+++ b/src/models/Property.js
@@ -11,22 +11,22 @@ const Property = sequelize.define('Property', {
   titulo: { type: DataTypes.STRING, allowNull: false },
 
   // ===== Atributos que usan tus controllers (mapeados a columnas en español) =====
-  propertyType: { type: DataTypes.STRING, field: 'tipo' },                // Tipo: piso completo / habitación
-  bedrooms:     { type: DataTypes.INTEGER, field: 'habitaciones' },       // Habitaciones
-  sizeM2:       { type: DataTypes.INTEGER, field: 'm2', allowNull: true },// M2 (nueva)
-  stayType:     { type: DataTypes.STRING, field: 'modalidad' },           // Tipo de contrato
-  neighborhood: { type: DataTypes.STRING, field: 'ubicacion' },           // Ubicación
+  propertyType: { type: DataTypes.STRING,  field: 'tipo' },                // Tipo de propiedad
+  bedrooms:     { type: DataTypes.INTEGER, field: 'habitaciones' },       // Número de habitaciones
+  sizeM2:       { type: DataTypes.INTEGER, field: 'm2', allowNull: true },// Metros cuadrados
+  stayType:     { type: DataTypes.STRING,  field: 'modalidad' },           // Tipo de contrato
+  neighborhood: { type: DataTypes.STRING,  field: 'ubicacion' },           // Ubicación
   terrace:      { type: DataTypes.BOOLEAN, field: 'terraza' },            // Terraza
-  availableFrom:{ type: DataTypes.DATEONLY, field: 'disponibleDesde' },   // Disponible desde
+  availableFrom:{ type: DataTypes.DATEONLY,field: 'disponibleDesde' },    // Disponible desde
   price:        { type: DataTypes.INTEGER, field: 'precio' },             // Precio
 
-  // Extras nuevos que quieres guardar
-  elevator:     { type: DataTypes.BOOLEAN, field: 'ascensor', allowNull: true }, // Ascensor (nuevo)
+  elevator:     { type: DataTypes.BOOLEAN, field: 'ascensor', allowNull: true }, // Ascensor
+  floorNumber:  { type: DataTypes.INTEGER, field: 'altura', allowNull: true },   // Altura/piso
 
   description:  { type: DataTypes.TEXT, field: 'descripcion' },
 
-  // ===== Nuevos campos que faltaban en la tabla =====
-  photos:       { type: DataTypes.TEXT, allowNull: true },                // JSON.stringify([...]) (nuevo)
+  published:    { type: DataTypes.BOOLEAN, defaultValue: true },          // Publicada
+  photos:       { type: DataTypes.TEXT, allowNull: true },                // JSON.stringify([...])
 }, {
   tableName: 'properties',
   // timestamps por defecto: createdAt / updatedAt

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,9 +1,10 @@
 const { Sequelize } = require("sequelize");
 const path = require("path");
 require("dotenv").config();
+// Resolve to project-root/config/dev.sqlite by default
 const url =
   process.env.DATABASE_URL ||
-  "sqlite:" + path.join(__dirname, "../config/dev.sqlite");
+  "sqlite:" + path.resolve(__dirname, "../../config/dev.sqlite");
 const sequelize = new Sequelize(url, { logging: false });
 module.exports = sequelize;
  


### PR DESCRIPTION
## Summary
- correct SQLite storage path used by Sequelize
- align Property model with database columns (elevator, floorNumber, published, photos)

## Testing
- `npx sequelize-cli db:migrate`
- `npm start` *(fails: invalid ELF header in bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68b43de87e348328a30ffc5ba1c6bf4f